### PR TITLE
Improve the likelihood of cleaning up all tables in the first iteration

### DIFF
--- a/lib/transient_record.rb
+++ b/lib/transient_record.rb
@@ -190,7 +190,7 @@ module TransientRecord
       drop_attempts = tables_to_remove.count * (1 + tables_to_remove.count) / 2
 
       drop_attempts.times do
-        table = tables_to_remove.shift
+        table = tables_to_remove.pop
         break if table.nil?
 
         begin
@@ -198,7 +198,7 @@ module TransientRecord
         rescue ActiveRecord::InvalidForeignKey, ActiveRecord::StatementInvalid
           # ActiveRecord::StatementInvalid is raised by MySQL when attempting to
           # drop a table that has foreign keys referring to it.
-          tables_to_remove << table
+          tables_to_remove.unshift(table)
         end
       end
 


### PR DESCRIPTION
When creating foreign keys, referred tables should be created before referring tables. This means, that `@transient_tables` will have referred tables come before that which are referring to them. While making a first iteration over the list to remove them, the loop will fail and push the referred tables to the end, to be able to remove them at the next iteration.

But if we traverse the list in the reverse order, we improving the likelihood of being able to remove all the tables on the first iteration and thus reducing the # of db queries.