### PR TITLE
Allow `define_model` followed by `create_table` in fluent interface

### DIFF
--- a/test/transient_record_test.rb
+++ b/test/transient_record_test.rb
@@ -97,6 +97,18 @@ class TransientRecordTest < Minitest::Spec
         TransientRecord::Models::User should inherit from ApplicationRecord, not #{TransientRecord::Models::User.superclass.name}
       ERROR
     end
+
+    it "allows .create_model call on return value" do
+      TransientRecord.define_model(:Post) do
+        validates :title, presence: true
+      end.create_table do |t|
+        t.string :title, null: false
+      end
+
+      assert_includes @connection.tables, "posts", <<~ERROR
+        The posts table should have been created
+      ERROR
+    end
   end
 
   describe ".cleanup" do


### PR DESCRIPTION
Kinda the same problem as with `assert_` minitest assertions - you need to remember which operand goes first (expected vs actual). This PR makes the fluent interface more fluent by allowing users to define both model and table in both orders of operations.

```ruby
TransientRecord.define_model(:User) do
  validates :email, presence: true
end.create_table do |t|
  t.string :email, null: false
end
```